### PR TITLE
Specify the license of the project in setup.py.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -3,3 +3,4 @@
 # Please add your name and email, or organization if applicable.
 
 Jason Brechin <brechinj@gmail.com>
+Clément Verna <cverna@fedoraproject.org> fedora-infra

--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,7 @@ setup(
     version=get_version(),
     description="Computed property model fields for Django",
     long_description=long_description,
+    license='MIT',
     author='Jason Brechin',
     author_email='brechinj@gmail.com',
     url='https://github.com/brechin/django-computed-property/',
@@ -25,7 +26,7 @@ setup(
     classifiers=[
         'Environment :: Web Environment',
         'Intended Audience :: Developers',
-        # 'License :: OSI Approved :: BSD License',
+        'License :: OSI Approved :: MIT License',
         'Operating System :: OS Independent',
         'Programming Language :: Python',
         'Programming Language :: Python :: 2',


### PR DESCRIPTION
This commit adds the license of the project in setup.py
so that is can be used by license checker tools.

Signed-off-by: Clement Verna <cverna@tutanota.com>