### PR TITLE
adding instructions for developers

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -92,6 +92,26 @@ both ``ComputedField`` and the other field class::
 Contributing
 ------------
 
-See the `contributing docs`_.
+End Users please see the `contributing docs`_.
 
-.. _contributing docs: https://github.com/orcasgit/django-computed-property/blob/master/CONTRIBUTING.rst
+.. _contributing docs: https://github.com/brechin/django-computed-property/blob/master/CONTRIBUTING.rst
+
+On top of the above, developers please consider the following:
+
+Reporting Issues or Suggestions
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+If you see an issue with the library or have a request for new functionality, please file an issue in GitHub.
+
+Please include specifics about which version of Python you're using, as well as which version of the django-computed-property library you're using.
+
+Whenever possible, include a code sample that demonstrates the issue you're seeing or the desired developer experience.
+
+Adding Test Cases
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The complete test suite is run using ``tox``.  This is how tests are run on Travis-CI, it includes all
+supported Python versions, all supported databases back ends, and all supported Django versions.  Arguably
+not what you would want to do, each time you add a test case, or make a minor change.
+
+To run the test suite in just one version of Python, against sqlite3, and using one chosen Django version, you … ?

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -92,7 +92,7 @@ both ``ComputedField`` and the other field class::
 Contributing
 ------------
 
-End Users please see the `contributing docs`_.
+Please also refer to the `contributing docs`_ in the repository.
 
 .. _contributing docs: https://github.com/brechin/django-computed-property/blob/master/CONTRIBUTING.rst
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -111,7 +111,19 @@ Adding Test Cases
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The complete test suite is run using ``tox``.  This is how tests are run on Travis-CI, it includes all
-supported Python versions, all supported databases back ends, and all supported Django versions.  Arguably
-not what you would want to do, each time you add a test case, or make a minor change.
+supported Python versions, all supported databases back ends, and all supported Django versions.
+Arguably not what you would want to do, each time you add a test case, or make a minor change.
 
-To run the test suite in just one version of Python, against sqlite3, and using one chosen Django version, you … ?
+To run the test suite in just one version of Python, against sqlite3, and using one chosen Django
+version, you still use ``tox``, instructing it to just test that single configuration combination.
+
+You can enumerate all the build configurations with ``tox -l``. From that list, you can choose the
+combination of python-django-database (or the ``py37-docs`` or ``py37-flake8`` builds) to run.
+
+For example::
+
+  $ tox -e py37-django111-sqlite
+
+Tox generally just requires that the version of python you're testing against is installed on your
+system. It will take care of creating the test environment from the configuration information in
+``tox.ini``.


### PR DESCRIPTION
I'm interested in adding test cases, and running them locally, too.
I created a virtual environment using python3.7, activated it, ran `pip install .`, then attempted `python setup.py test`, and it complained about not having configured django.
So I checked how you run tests on travis-ci, and found you use `tox`.  no clue what it is, but if it works on travis, why not here?  so I installed it and started it.  that was some 15 minutes ago, and my laptop is still running tests, against far too many configurations.  initially it complained about a missing pypy ( `ERROR: InterpreterNotFound: pypy` ).
I hope that this PR can be a start for somewhat better developers instructions.